### PR TITLE
Only show form at a time on the propose vote/member pages.

### DIFF
--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -56,22 +56,60 @@ $(document).ready(function () {
   // Forms on the Voting & proposals page
   // If JavaScript is disabled, they all show by default
   $('.form-to-hide').hide();
+
+  var cancel_button = $('<span class="cancel">cancel</span>');
+  $('.form-to-hide').each(function() {
+    var cloned_cancel = cancel_button.clone();
+    $(this).find(':submit').after(cloned_cancel);
+    
+    // make it slide back up on click
+    cloned_cancel.click(function() {
+    $(this).closest('.form-to-hide').slideUp();
+    })
+  })
+
+
   $('.button-form-show').show();
 
   $('.button-form-show').click(function() {
     $(this).toggleClass('clicked');
   });
-  
+  // this isn't quite behaving how it should:
+  // ideally these slideDown() animations only fire after a 
+  // slideUp, but putting them in the call back means that these
+  // end up being called twice.
+  // TODO - fix this fire only at the right time
+  //
   $('#button-proposal').click(function() {
-    $('#propose_freeform_form').toggle('medium');
+      if (!$(this).hasClass('active')) {
+
+        $('.button-form-show').removeClass('active');
+
+        $(this).addClass('active');
+
+        $('.form-to-hide').not( $('.active')).slideUp( function() {
+          $('#propose_freeform_form').slideDown('medium');
+        });
+     
+      }
   });
+
   $('#button-member-invite').click(function() {
-    $('#propose_new_member_form').toggle('medium');
+     if (!$(this).hasClass('active')) {
+
+      $('.button-form-show').removeClass('active');
+
+      $(this).addClass('active');
+
+      $('.form-to-hide').not( $('.active')).slideUp();
+
+      $('#propose_new_member_form').slideDown('medium');
+     }
   })
+
   $('#button-constitution-change').click(function() {
     $(location).attr('href','/amendments');
   });
-  
 
   // Notifications
   if ($('#lightbox div.notification').length > 0) {


### PR DESCRIPTION
Only a single form is should be visible when proposing members
or votes.
